### PR TITLE
Improve import

### DIFF
--- a/src/wheezy/template/builder.py
+++ b/src/wheezy/template/builder.py
@@ -97,6 +97,8 @@ class SourceBuilder(object):
 
     def build_module(self, nodes):
         builder = BlockBuilder(self.rules, lineno=self.lineno)
-        builder.add(self.lineno + 1, "local_defs = {}; super_defs = {}")
+        builder.add(self.lineno + 1,
+                    "def get_defs(ctx, local_defs, super_defs):")
+        builder.start_block()
         builder.build_token(self.lineno + 2, "module", nodes)
         return builder.to_string()


### PR DESCRIPTION
Hi, I added context sharing on import to make following example work

```
from wheezy.template.engine import Engine
from wheezy.template.ext.core import CoreExtension
from wheezy.template.loader import DictLoader

a = '''
@require(test)
@def test_a():
    @test
@end
'''

b = '''
@from "a" import test_a
@test_a()
'''

engine = Engine(
    loader=DictLoader({'a': a, 'b': b}),
    extensions=[CoreExtension()],
)
template_b = engine.get_template('b')
print(template_b.render({'test': 'some test text in context'}))
```

Also I added 'as' op to require syntax to make syntax `require(value as alias)` possible and added `global_vars` argument to engine init.