### PR TITLE
To determine if context is file or json string, use os.path.isfile

### DIFF
--- a/src/wheezy/template/console.py
+++ b/src/wheezy/template/console.py
@@ -1,5 +1,6 @@
 import getopt
 import json
+import os
 import sys
 import typing
 
@@ -48,7 +49,7 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
 def load_context(sources: typing.List[str]) -> typing.Mapping[str, typing.Any]:
     c: typing.Dict[str, typing.Any] = {}
     for s in sources:
-        if s.endswith(".json"):
+        if os.path.isfile(s):
             d = json.load(open(s))
         else:
             d = json.loads(s)


### PR DESCRIPTION
Rather than checking file extension, which can be misleading, use `os.path.isfile` to determine if a given context is a file.

My personal motivation is using the CLI in shell scripts where context data exists as a variable or as the result of a subshell expansion, tempting me to use shell features to create a temporary file (of arbitrary name; without `.json` suffix) to pass to `wheezy.template`.

For example, in Zsh:

```console
% data='{"entries": [1, 2, 3]}'
% tmpl=('@require(entries)' '@(count = f"{len(entries)}")Entry Count: @count')
% wheezy.template =(<<<${(F)tmpl}) =(<<<$data)
```
