### PR TITLE
adds a custom r-value expression scope symbol

### DIFF
--- a/src/wheezy/template/ext/core.py
+++ b/src/wheezy/template/ext/core.py
@@ -406,7 +406,7 @@ def build_end(
 class CoreExtension(object):
     """Includes basic statements, variables processing and markup."""
 
-    def __init__(self, token_start: str = "@", line_join: str = "\\"):
+    def __init__(self, token_start: str = "@", token_lvalue: str = "{", token_rvalue: str = "}", line_join: str = "\\"):
         def markup_token(m: typing.Match[str]) -> Token:
             """Produces markup token."""
             return (
@@ -425,7 +425,7 @@ class CoreExtension(object):
                 stmt_token,
             ),
             200: (re.compile(r"%s(\w+(\.\w+)*)" % token_start), var_token),
-            201: (re.compile(r"%s{(.*?)}" % token_start), rvalue_token),
+            201: (re.compile(r"%s%s(.*?)%s" % (token_start, token_lvalue, token_rvalue)), rvalue_token),
             999: (
                 re.compile(
                     r".+?(?=(?<!%s)%s(?!%s))|.+"


### PR DESCRIPTION
```python
if __name__ == '__main__':
    from wheezy.template import DictLoader

    template = r"""
@require(l1,l2,count)
[
@<',\n'.join(['{%s}' % ',\n    '.join([f'"{k}" : {v}' for k,v in zip(l2, row)]) for row in l1])>
]
"""
    l1 = [range(5)] * 5
    l2 = range(5)
    engine = Engine(
        loader=DictLoader({"template": template}),
        extensions=[CoreExtension(token_lvalue='<', token_rvalue='>'), CodeExtension()]
    )
    print(engine.get_template("template").render({"l1": l1, "l2": l2, "count": len(l1)}))
```

see issue #50 for details.